### PR TITLE
Remove redundant setup.

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,6 @@ If you wish artbollocks-mode to be loaded automatically, add the following
 to your .emacs file immediately after the autoload statement:
 
 (add-hook 'text-mode-hook 'artbollocks-mode)
-(add-hook 'org-mode-hook 'artbollocks-mode)
 
 Manual Usage
 ============

--- a/artbollocks-mode.el
+++ b/artbollocks-mode.el
@@ -40,7 +40,6 @@
 ;;
 ;; (require 'artbollocks-mode)
 ;; (add-hook 'text-mode-hook 'artbollocks-mode)
-;; (add-hook 'org-mode-hook 'artbollocks-mode)
 ;;
 ;; or
 ;;


### PR DESCRIPTION
`org-mode` (and many other modes, like `outline-mode`, `tex-mode`, `html-mode` etc.) will run `text-mode-hook`, so there is no need to mention them here.
